### PR TITLE
Fixed bug in flint value calculation

### DIFF
--- a/ant_quantization/antquant/quant_modules.py
+++ b/ant_quantization/antquant/quant_modules.py
@@ -246,7 +246,7 @@ class Quantizer(nn.Module):
             exp_value = -(exp_bit - 1)
             mant_bit = value_bit - exp_bit
             for j in range(int(2 ** mant_bit)):
-                v = 2 ** exp_value * (1 + 2 ** (-mant_bit) * j)
+                v = 2 ** (exp_value + exp_base) * (1 + 2 ** (-mant_bit) * j)
                 values.append(v)
                 if self.is_signed:
                     values.append(-v)


### PR DESCRIPTION
Exponent bias was ignored when calculating flint values with negative non-biased exponent